### PR TITLE
Fixing setHMACKey arguments to pass a UINT8ARRAY instead of a string.

### DIFF
--- a/lib/hotp.js
+++ b/lib/hotp.js
@@ -39,7 +39,7 @@ class HOTP {
    */
   genOTP(movingFactor) {
     const hmacSha = new jssha('SHA-1', 'BYTES');
-    hmacSha.setHMACKey(base32.decode(this.key).toString(), 'BYTES');
+    hmacSha.setHMACKey(base32.decode(this.key), 'UINT8ARRAY');
 
     const factorByte = this._factor2ByteText(movingFactor);
     hmacSha.update(factorByte);


### PR DESCRIPTION
When doing `base32.decode(this.key).toString()`, the result is an array of unsigned ints, but we are passing it to jssha as `BYTES`. This causes the values in the negative range to be read as positive, effectively changing the secret. 

Since `base32.decode(this.key)` produces a UINT8ARRAY, the proper parameter to jssha is `setHMACKey(base32.decode(this.key), 'UINT8ARRAY')`